### PR TITLE
Enable 32-bit floating point format support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ endif
 DEP_FLAGS += -I$(DEP_PATH)/include
 DEP_LDFLAGS += -L$(DEP_PATH)/lib
 
-FFMPEG_FORMATS += --enable-muxer=wav --enable-encoder=pcm_s16le --enable-encoder=pcm_s24le
-FFMPEG_FORMATS += --enable-muxer=aiff --enable-encoder=pcm_s16be --enable-encoder=pcm_s24be
+FFMPEG_FORMATS += --enable-muxer=wav --enable-encoder=pcm_s16le --enable-encoder=pcm_s24le --enable-encoder=pcm_f32le
+FFMPEG_FORMATS += --enable-muxer=aiff --enable-encoder=pcm_s16be --enable-encoder=pcm_s24be --enable-encoder=pcm_f32be
 FFMPEG_FORMATS += --enable-libmp3lame --enable-muxer=mp3 --enable-encoder=libmp3lame
 # FFMPEG_FORMATS += --enable-libopus --enable-muxer=opus --enable-encoder=libopus
 FFMPEG_FORMATS += --enable-muxer=flac --enable-encoder=flac

--- a/src/Recorder.cpp
+++ b/src/Recorder.cpp
@@ -178,11 +178,13 @@ struct Encoder {
 		if (format == "wav") {
 			if (depth == 16) audioEncoderName = "pcm_s16le";
 			else if (depth == 24) audioEncoderName = "pcm_s24le";
+			else if (depth == 32) audioEncoderName = "pcm_f32le";
 			else assert(0);
 		}
 		else if (format == "aiff") {
 			if (depth == 16) audioEncoderName = "pcm_s16be";
 			else if (depth == 24) audioEncoderName = "pcm_s24be";
+			else if (depth == 32) audioEncoderName = "pcm_f32be";
 			else assert(0);
 		}
 		else if (format == "flac") audioEncoderName = "flac";
@@ -225,11 +227,13 @@ struct Encoder {
 		if (format == "wav" || format == "aiff" || format == "flac") {
 			if (depth == 16) audioCtx->sample_fmt = AV_SAMPLE_FMT_S16;
 			else if (depth == 24) audioCtx->sample_fmt = AV_SAMPLE_FMT_S32;
+			else if (depth == 32) audioCtx->sample_fmt = AV_SAMPLE_FMT_FLT;
 			else assert(0);
 		}
 		else if (format == "alac") {
 			if (depth == 16) audioCtx->sample_fmt = AV_SAMPLE_FMT_S16P;
 			else if (depth == 24) audioCtx->sample_fmt = AV_SAMPLE_FMT_S32P;
+			else if (depth == 32) audioCtx->sample_fmt = AV_SAMPLE_FMT_FLTP;
 			else assert(0);
 		}
 		else if (format == "mp3") audioCtx->sample_fmt = AV_SAMPLE_FMT_FLTP;
@@ -497,6 +501,13 @@ struct Encoder {
 			for (int c = 0; c < audioCtx->channels; c++) {
 				float v = clamp(input[c], -1.f, 1.f);
 				output[c][audioFrameSampleIndex] = v;
+			}
+		}
+		else if (audioCtx->sample_fmt == AV_SAMPLE_FMT_FLT) {
+			float** output = (float**) audioFrame->data;
+			for (int c = 0; c < audioCtx->channels; c++) {
+				float v = clamp(input[c], -1.f, 1.f);
+				output[c][audioFrameSampleIndex * audioCtx->channels + c] = v;
 			}
 		}
 		else if (audioCtx->sample_fmt == AV_SAMPLE_FMT_S16) {
@@ -975,7 +986,7 @@ struct Recorder : Module {
 	}
 
 	std::vector<int> getDepths() {
-		return {16, 24};
+		return {16, 24, 32};
 	}
 
 	bool isDepthShown() {


### PR DESCRIPTION
Sorry for bothering! A guy from local chat asked for 32-bit floating point format recording support and I tried to enable it in VCV Recorder. It works fine for me on Linux system, but I cannot get it to cross-compile for Windows even without any changes. I thought that if it's already builds well with your build system then I can ask for that small feature to be included in the official plugin version.